### PR TITLE
Add cooldown setting for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
https://docs.zizmor.sh/audits/#dependabot-cooldown

> By default, Dependabot does not perform any "cooldown" on dependency updates. In other words, a regularly scheduled Dependabot run may perform an update on a dependency that was just released moments before the run began. This presents both stability and supply-chain security risks.
